### PR TITLE
fix padding issue on scroll bar/white space on dashboard

### DIFF
--- a/frontend/src/assets/stylesheets/group_index.css
+++ b/frontend/src/assets/stylesheets/group_index.css
@@ -98,7 +98,7 @@
 
 .group-index-viewer {
   width: 80%;
-  padding-top: 175px;
+  padding-top: 75px;
   box-sizing: border-box;
   margin: auto;
   display: flex;


### PR DESCRIPTION
Looks like the padding got pushed to 175. I bumped it down to 75. Looks much better, and fixes the issue of all that white space on the bottom.